### PR TITLE
Disable web security, set storage quota

### DIFF
--- a/autorun.brs
+++ b/autorun.brs
@@ -199,11 +199,13 @@ Sub CreateHtmlWidget()
     url: "https://player.fugo.ai",
     focus_enabled: true,
     javascript_enabled: true,
+    storage_quota: "2000000000",
     storage_path: "./fugo-storage",
     inspector_server: {
       ip_addr: "0.0.0.0",
       port: 2999
-    }
+    },
+    security_params: { websecurity: false }
   }
 
   gaa.htmlWidget = CreateObject("roHtmlWidget", rect, config)


### PR DESCRIPTION

# should be merged after testing on a device

I saw these settings in an example that BrightSign support sent me.

`storage_quota: "2000000000"` is a bit sketchy because their doc
says that

> If the storage path is specified without a storage quota, Chromium defaults to reserving 1GB plus 10% of the total size of the storage device.

Which means that 2GB quota will be less than a default quota on
a 32GB disk (4 GB) but it benefits small 4 GB disks (which defaults to 1.3 GB).