### PR TITLE
Remove setting video mode

### DIFF
--- a/autorun.brs
+++ b/autorun.brs
@@ -90,8 +90,6 @@ Sub DoCanonicalInit()
 
   DebugLog("BS: Setting video mode...")
   gaa.vm = CreateObject("roVideoMode")
-  gaa.vm.setMode("1920x1080x60p")
-
 
   DebugLog("BS: Setting network hotplug...")
   gaa.hp = CreateObject("roNetworkHotplug")


### PR DESCRIPTION
Setting a video mode has been moved to Player JS so removing it from here since it messes up screen setup.